### PR TITLE
Improve Nobat scraper robustness and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# chang1
+# Nobat.ir Doctor Scraper Extension
+
+This repository contains a Chrome extension that scrapes doctor information from [nobat.ir](https://nobat.ir/) based on a list of doctors presented on the site. The extension collects profile data for each doctor and exports the results as a CSV file.
+
+## Features
+
+- Extracts all doctor profile links from the active doctors list page and automatically expands supported "load more" buttons to capture the full set of results.
+- Visits each profile sequentially with a configurable delay and retry policy to gather detailed information without overwhelming the site.
+- Reveals hidden phone numbers, normalises Persian digits, and deduplicates addresses/phones collected from multiple DOM patterns and structured data.
+- Aggregates multiple clinic addresses and phone numbers for each doctor and converts the output to UTF-8 CSV with a BOM for Excel compatibility.
+- Provides a popup interface that persists delay/retry settings, shows real-time progress, recent profile details, retry state, and any errors.
+- Downloads a partial CSV automatically if the scraping run is stopped before completion.
+
+## File Overview
+
+- `extension/manifest.json` – Chrome extension manifest (Manifest V3).
+- `extension/background.js` – Service worker that orchestrates scraping and CSV generation.
+- `extension/content-script.js` – Extracts links and profile details within Nobat.ir pages.
+- `extension/csv-export.js` – Helper functions for building and downloading CSV files.
+- `extension/popup.html` & `extension/popup.js` – Popup UI for controlling the scraper.
+
+## Loading the Extension Locally
+
+1. Open **chrome://extensions** in Chrome.
+2. Enable **Developer mode** (toggle in the top-right corner).
+3. Click **Load unpacked** and select the `extension` directory from this repository.
+4. Navigate to a Nobat.ir doctors list page and open the extension popup. Adjust the delay (seconds between profiles) and max retries if needed, then press **Start**.
+5. While scraping is in progress you can observe the status, last processed profile, and any retry or error information. Press **Stop** to end the run early and download a partial CSV.
+
+The resulting CSV file will be downloaded automatically once scraping completes (or is stopped).

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,925 @@
+import { downloadCsv } from "./csv-export.js";
+
+const STATUS_STORAGE_KEY = "nobatDoctorScraperStatus";
+const CONFIG_STORAGE_KEY = "nobatDoctorScraperConfig";
+const DEFAULT_CONFIG = {
+  delayMs: 2500,
+  maxRetries: 2,
+};
+const MAX_RETRY_LIMIT = 5;
+
+const DIGIT_MAP = {
+  "۰": "0",
+  "۱": "1",
+  "۲": "2",
+  "۳": "3",
+  "۴": "4",
+  "۵": "5",
+  "۶": "6",
+  "۷": "7",
+  "۸": "8",
+  "۹": "9",
+  "٠": "0",
+  "١": "1",
+  "٢": "2",
+  "٣": "3",
+  "٤": "4",
+  "٥": "5",
+  "٦": "6",
+  "٧": "7",
+  "٨": "8",
+  "٩": "9",
+};
+
+const state = {
+  isScraping: false,
+  queue: [],
+  results: [],
+  currentIndex: 0,
+  listTabId: null,
+  listWindowId: null,
+  listTabIndex: null,
+  scraperTabId: null,
+  delayMs: DEFAULT_CONFIG.delayMs,
+  maxRetries: DEFAULT_CONFIG.maxRetries,
+  errors: [],
+  lastDoctor: null,
+  retrying: null,
+  stopRequested: false,
+  visited: new Set(),
+};
+
+let resolveConfigReady;
+const configReady = new Promise((resolve) => {
+  resolveConfigReady = resolve;
+});
+
+function convertLocaleDigits(value) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  return String(value).replace(/[٠-٩۰-۹]/g, (digit) => DIGIT_MAP[digit] ?? digit);
+}
+
+function normaliseWhitespace(value) {
+  return convertLocaleDigits(value)
+    .replace(/\u200c/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normaliseText(value) {
+  return normaliseWhitespace(value);
+}
+
+function normalisePhoneValue(value) {
+  const text = normaliseWhitespace(value);
+  if (!text) {
+    return "";
+  }
+  return text;
+}
+
+function phoneKey(_, value) {
+  return convertLocaleDigits(value).replace(/[^0-9+]/g, "");
+}
+
+function collectValues(...values) {
+  const buffer = [];
+  values.forEach((value) => {
+    if (Array.isArray(value)) {
+      buffer.push(...value);
+    } else if (value !== undefined && value !== null) {
+      buffer.push(value);
+    }
+  });
+  return buffer;
+}
+
+function uniqueNormalisedList(values, transform = normaliseText, keyFn) {
+  const seen = new Set();
+  const output = [];
+
+  values.forEach((value) => {
+    const transformed = transform ? transform(value) : value;
+    if (!transformed) {
+      return;
+    }
+    const key = keyFn ? keyFn(value, transformed) : transformed;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    output.push(transformed);
+  });
+
+  return output;
+}
+
+function toNormalisedList(...values) {
+  return uniqueNormalisedList(collectValues(...values));
+}
+
+function toNormalisedPhoneList(...values) {
+  return uniqueNormalisedList(collectValues(...values), normalisePhoneValue, phoneKey);
+}
+
+function cleanDoctorCode(rawValue) {
+  const text = normaliseText(rawValue);
+  if (!text) {
+    return "";
+  }
+  const digits = text.replace(/[^0-9]/g, "");
+  return digits || text;
+}
+
+function normaliseDoctorData(data = {}, url) {
+  const addresses = toNormalisedList(data.addresses, data.address);
+  const phones = toNormalisedPhoneList(data.phones, data.phone);
+
+  const resolvedUrl = typeof url === "string" && url.length ? url : data.url || "";
+
+  return {
+    url: resolvedUrl,
+    name: normaliseText(data.name || ""),
+    specialty: normaliseText(data.specialty || ""),
+    code: cleanDoctorCode(data.code || data.doctorCode || ""),
+    city: normaliseText(data.city || ""),
+    address: addresses,
+    phones,
+  };
+}
+
+function normaliseDoctorProfileUrl(rawUrl) {
+  if (!rawUrl) {
+    return null;
+  }
+  try {
+    const url = new URL(rawUrl, "https://nobat.ir/");
+    if (!/(^|\.)nobat\.ir$/i.test(url.hostname)) {
+      return null;
+    }
+    url.protocol = "https:";
+    url.hash = "";
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function isNobatDoctorHost(url) {
+  if (!url) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return /(^|\.)nobat\.ir$/i.test(parsed.hostname);
+  } catch (error) {
+    return false;
+  }
+}
+
+function ensureDelay(value, fallback = state.delayMs ?? DEFAULT_CONFIG.delayMs) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return Math.max(0, Math.round(fallback));
+  }
+  return Math.max(0, Math.round(numeric));
+}
+
+function ensureRetries(value, fallback = state.maxRetries ?? DEFAULT_CONFIG.maxRetries) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return Math.max(0, Math.round(fallback));
+  }
+  return Math.min(MAX_RETRY_LIMIT, Math.max(0, Math.round(numeric)));
+}
+
+async function loadPersistedConfig() {
+  try {
+    const stored = await chrome.storage.local.get(CONFIG_STORAGE_KEY);
+    const persisted = stored?.[CONFIG_STORAGE_KEY];
+    const delay = ensureDelay(persisted?.delayMs, DEFAULT_CONFIG.delayMs);
+    const retries = ensureRetries(persisted?.maxRetries, DEFAULT_CONFIG.maxRetries);
+    state.delayMs = delay;
+    state.maxRetries = retries;
+    if (!persisted || persisted.delayMs !== delay || persisted.maxRetries !== retries) {
+      await chrome.storage.local.set({
+        [CONFIG_STORAGE_KEY]: { delayMs: delay, maxRetries: retries },
+      });
+    }
+  } catch (error) {
+    console.error("Failed to load persisted configuration", error);
+    state.delayMs = DEFAULT_CONFIG.delayMs;
+    state.maxRetries = DEFAULT_CONFIG.maxRetries;
+  } finally {
+    if (typeof resolveConfigReady === "function") {
+      resolveConfigReady();
+      resolveConfigReady = null;
+    }
+  }
+}
+
+loadPersistedConfig();
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function queryActiveTab() {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(tabs[0]);
+    });
+  });
+}
+
+function createTab(createProperties) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.create(createProperties, (tab) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(tab);
+    });
+  });
+}
+
+function updateTab(tabId, updateProperties) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.update(tabId, updateProperties, (tab) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(tab);
+    });
+  });
+}
+
+function removeTab(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.remove(tabId, () => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function injectContentScript(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.scripting.executeScript(
+      {
+        target: { tabId },
+        files: ["content-script.js"],
+      },
+      () => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve();
+      }
+    );
+  });
+}
+
+function sendMessageToTab(tabId, message) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, message, (response) => {
+      if (chrome.runtime.lastError) {
+        const error = new Error(chrome.runtime.lastError.message);
+        if (tabId === state.scraperTabId && /No tab with id/i.test(error.message)) {
+          state.scraperTabId = null;
+        }
+        reject(error);
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+function waitForTabLoad(tabId, timeoutMs = 45000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out while waiting for the page to finish loading."));
+    }, timeoutMs);
+
+    function handleUpdate(updatedTabId, changeInfo) {
+      if (updatedTabId !== tabId) {
+        return;
+      }
+      if (changeInfo.status === "complete") {
+        cleanup();
+        resolve();
+      }
+    }
+
+    function handleRemoval(removedTabId) {
+      if (removedTabId !== tabId) {
+        return;
+      }
+      cleanup();
+      reject(new Error("The tab was closed before loading completed."));
+    }
+
+    function cleanup() {
+      clearTimeout(timeout);
+      chrome.tabs.onUpdated.removeListener(handleUpdate);
+      chrome.tabs.onRemoved.removeListener(handleRemoval);
+    }
+
+    chrome.tabs.onUpdated.addListener(handleUpdate);
+    chrome.tabs.onRemoved.addListener(handleRemoval);
+  });
+}
+
+function clearError(url) {
+  if (!state.errors.length) {
+    return;
+  }
+  state.errors = state.errors.filter((error) => error.url !== url);
+}
+
+function recordError(url, message, extra = {}) {
+  if (!message) {
+    clearError(url);
+    return;
+  }
+  clearError(url);
+  state.errors.push({ url, message, ...extra });
+}
+
+async function updateStatus(partial = {}) {
+  await configReady;
+
+  const total = state.queue.length;
+  const processed = Math.min(state.currentIndex, total);
+  const pending = Math.max(total - processed, 0);
+
+  const status = {
+    isScraping: state.isScraping,
+    total,
+    processed,
+    pending,
+    errors: state.errors.map((error) => ({ ...error })),
+    delayMs: state.delayMs,
+    maxRetries: state.maxRetries,
+    lastDoctor: state.lastDoctor ? { ...state.lastDoctor } : null,
+    retrying: state.retrying ? { ...state.retrying } : null,
+    message: partial.message ?? (state.isScraping ? "Scraping in progress..." : "Idle."),
+  };
+
+  if (partial.total !== undefined) {
+    status.total = partial.total;
+  }
+  if (partial.processed !== undefined) {
+    status.processed = partial.processed;
+  }
+  if (partial.pending !== undefined) {
+    status.pending = partial.pending;
+  }
+  if (partial.errors) {
+    status.errors = partial.errors;
+  }
+  if (partial.lastDoctor) {
+    status.lastDoctor = partial.lastDoctor;
+  }
+  if (partial.retrying) {
+    status.retrying = partial.retrying;
+  }
+
+  await chrome.storage.local.set({ [STATUS_STORAGE_KEY]: status });
+
+  try {
+    chrome.runtime.sendMessage({ type: "SCRAPE_STATUS", payload: status });
+  } catch (error) {
+    // The popup might not be open; ignore the error.
+  }
+}
+
+async function applyConfig(partialConfig = {}, { persist = false } = {}) {
+  await configReady;
+  const updated = {
+    delayMs: state.delayMs,
+    maxRetries: state.maxRetries,
+  };
+
+  if (partialConfig.delayMs !== undefined) {
+    updated.delayMs = ensureDelay(partialConfig.delayMs, updated.delayMs);
+  }
+  if (partialConfig.maxRetries !== undefined) {
+    updated.maxRetries = ensureRetries(partialConfig.maxRetries, updated.maxRetries);
+  }
+
+  state.delayMs = updated.delayMs;
+  state.maxRetries = updated.maxRetries;
+
+  if (persist) {
+    await chrome.storage.local.set({
+      [CONFIG_STORAGE_KEY]: {
+        delayMs: state.delayMs,
+        maxRetries: state.maxRetries,
+      },
+    });
+  }
+
+  return { delayMs: state.delayMs, maxRetries: state.maxRetries };
+}
+
+async function getDoctorLinksFromTab(tabId) {
+  let response;
+  try {
+    response = await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
+  } catch (error) {
+    if (/Receiving end does not exist/i.test(error.message)) {
+      await injectContentScript(tabId);
+      response = await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
+    } else {
+      throw error;
+    }
+  }
+
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+
+  const rawLinks = Array.isArray(response?.links) ? response.links : [];
+  const unique = [];
+  const seen = new Set();
+
+  rawLinks.forEach((link) => {
+    const normalised = normaliseDoctorProfileUrl(link);
+    if (normalised && !seen.has(normalised)) {
+      seen.add(normalised);
+      unique.push(normalised);
+    }
+  });
+
+  return unique;
+}
+
+async function createScraperTab(url) {
+  const createOptions = {
+    url,
+    active: false,
+    autoDiscardable: true,
+  };
+
+  if (Number.isInteger(state.listWindowId)) {
+    createOptions.windowId = state.listWindowId;
+  }
+  if (Number.isInteger(state.listTabIndex)) {
+    createOptions.index = state.listTabIndex;
+  }
+
+  const tab = await createTab(createOptions);
+  state.scraperTabId = tab.id;
+  await waitForTabLoad(tab.id);
+  return tab.id;
+}
+
+async function ensureScraperTab(url) {
+  const targetUrl = normaliseDoctorProfileUrl(url);
+  if (!targetUrl) {
+    throw new Error("Invalid doctor profile URL provided.");
+  }
+
+  if (state.scraperTabId) {
+    try {
+      await updateTab(state.scraperTabId, { url: targetUrl, active: false, autoDiscardable: true });
+      await waitForTabLoad(state.scraperTabId);
+      return state.scraperTabId;
+    } catch (error) {
+      console.warn("Failed to reuse existing scraper tab", error);
+      try {
+        await cleanupScraperTab();
+      } catch (cleanupError) {
+        console.warn("Failed to clean up scraper tab", cleanupError);
+      }
+    }
+  }
+
+  return createScraperTab(targetUrl);
+}
+
+async function cleanupScraperTab() {
+  if (!state.scraperTabId) {
+    return;
+  }
+  const tabId = state.scraperTabId;
+  state.scraperTabId = null;
+  try {
+    await removeTab(tabId);
+  } catch (error) {
+    if (!/No tab with id/i.test(error.message)) {
+      console.warn("Failed to remove scraper tab", error);
+    }
+  }
+}
+
+async function scrapeDoctorProfile(url) {
+  const tabId = await ensureScraperTab(url);
+
+  let response;
+  try {
+    response = await sendMessageToTab(tabId, { type: "SCRAPE_DOCTOR_DETAILS" });
+  } catch (error) {
+    if (/Receiving end does not exist/i.test(error.message)) {
+      await injectContentScript(tabId);
+      response = await sendMessageToTab(tabId, { type: "SCRAPE_DOCTOR_DETAILS" });
+    } else {
+      throw error;
+    }
+  }
+
+  if (response?.error) {
+    throw new Error(response.error);
+  }
+
+  if (!response || !response.data) {
+    throw new Error("No data was returned from the doctor profile page.");
+  }
+
+  return normaliseDoctorData(response.data, url);
+}
+
+async function scrapeDoctorProfileWithRetries(url) {
+  const attempts = Math.max(0, state.maxRetries) + 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      state.retrying = attempt > 1 ? { attempt, total: attempts, url } : null;
+      if (state.retrying) {
+        await updateStatus({
+          retrying: { ...state.retrying },
+          message: `Retrying current profile (${attempt} / ${attempts})...`,
+        });
+      }
+      const data = await scrapeDoctorProfile(url);
+      state.retrying = null;
+      return data;
+    } catch (error) {
+      if (attempt >= attempts) {
+        state.retrying = null;
+        throw error;
+      }
+      console.warn(`Attempt ${attempt} failed for ${url}. Retrying...`, error);
+      await delay(Math.max(state.delayMs, 1000));
+    }
+  }
+
+  throw new Error("Failed to scrape doctor profile after retries.");
+}
+
+async function finaliseScraping({ partial = false } = {}) {
+  const total = state.queue.length;
+  const processed = Math.min(state.currentIndex, total);
+  const pending = Math.max(total - processed, 0);
+
+  await cleanupScraperTab();
+
+  if (!state.results.length) {
+    await updateStatus({
+      message: partial
+        ? "Scraping stopped before any data was collected."
+        : "No data was collected.",
+      isScraping: false,
+      total,
+      processed,
+      pending,
+    });
+    resetState();
+    return;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:T]/g, "-").split(".")[0];
+  const prefix = partial ? "nobat-doctors-partial" : "nobat-doctors";
+  const filename = `${prefix}-${timestamp}.csv`;
+
+  const rows = state.results.map((item) => ({
+    name: item.name,
+    specialty: item.specialty,
+    code: item.code,
+    city: item.city,
+    address: item.address,
+    phones: item.phones,
+  }));
+
+  try {
+    await downloadCsv(filename, rows);
+    await updateStatus({
+      message: partial
+        ? "Scraping stopped early. Partial CSV downloaded."
+        : "Scraping completed.",
+      isScraping: false,
+      total,
+      processed,
+      pending,
+    });
+  } catch (error) {
+    recordError("download", error.message);
+    await updateStatus({
+      message: `Failed to save CSV: ${error.message}`,
+      isScraping: false,
+      total,
+      processed,
+      pending,
+    });
+  }
+
+  resetState();
+}
+
+function resetState() {
+  state.isScraping = false;
+  state.queue = [];
+  state.results = [];
+  state.currentIndex = 0;
+  state.listTabId = null;
+  state.listWindowId = null;
+  state.listTabIndex = null;
+  state.scraperTabId = null;
+  state.errors = [];
+  state.lastDoctor = null;
+  state.retrying = null;
+  state.stopRequested = false;
+  state.visited = new Set();
+}
+
+async function processQueue() {
+  while (state.isScraping && state.currentIndex < state.queue.length) {
+    if (state.stopRequested) {
+      break;
+    }
+
+    const url = state.queue[state.currentIndex];
+    if (!url) {
+      state.currentIndex += 1;
+      continue;
+    }
+
+    if (state.visited.has(url)) {
+      state.currentIndex += 1;
+      await updateStatus({
+        message: `Skipped duplicate link (${state.currentIndex} / ${state.queue.length}).`,
+      });
+      continue;
+    }
+
+    state.visited.add(url);
+
+    try {
+      const data = await scrapeDoctorProfileWithRetries(url);
+      clearError(url);
+      state.results.push(data);
+      state.lastDoctor = {
+        name: data.name || data.url || url,
+        url: data.url || url,
+      };
+    } catch (error) {
+      console.error("Failed to scrape doctor page", url, error);
+      recordError(url, error.message);
+      state.results.push(
+        normaliseDoctorData(
+          {
+            name: "",
+            specialty: "",
+            code: "",
+            city: "",
+            addresses: [],
+            phones: [],
+          },
+          url
+        )
+      );
+    }
+
+    state.currentIndex += 1;
+
+    await updateStatus({
+      message: `Processed ${Math.min(state.currentIndex, state.queue.length)} of ${state.queue.length}`,
+    });
+
+    if (state.stopRequested || state.currentIndex >= state.queue.length) {
+      break;
+    }
+
+    if (state.delayMs > 0) {
+      await delay(state.delayMs);
+    }
+  }
+
+  const partial = state.stopRequested;
+  state.isScraping = false;
+  state.stopRequested = false;
+
+  try {
+    await finaliseScraping({ partial });
+  } catch (error) {
+    console.error("Scraping finalisation failed", error);
+    recordError("finalise", error.message);
+    await cleanupScraperTab();
+    await updateStatus({
+      message: `Scraping finalisation failed: ${error.message}`,
+      isScraping: false,
+    });
+    resetState();
+  }
+}
+
+async function handleStartScraping(options = {}) {
+  await configReady;
+
+  if (state.isScraping) {
+    return { status: "already-running" };
+  }
+
+  const activeTab = await queryActiveTab();
+  if (!activeTab || !activeTab.id) {
+    throw new Error("No active tab detected.");
+  }
+  if (!isNobatDoctorHost(activeTab.url)) {
+    throw new Error("Please open a Nobat.ir doctors list page before starting.");
+  }
+
+  state.listTabId = activeTab.id;
+  state.listWindowId = activeTab.windowId ?? null;
+  state.listTabIndex = typeof activeTab.index === "number" ? activeTab.index + 1 : null;
+
+  await cleanupScraperTab();
+
+  await applyConfig(options, { persist: true });
+
+  const links = await getDoctorLinksFromTab(state.listTabId);
+  if (!links.length) {
+    resetState();
+    await updateStatus({
+      message: "No doctor links found on this page.",
+      isScraping: false,
+      total: 0,
+      processed: 0,
+      pending: 0,
+    });
+    return { status: "no-links" };
+  }
+
+  state.queue = links.slice();
+  state.results = [];
+  state.currentIndex = 0;
+  state.errors = [];
+  state.lastDoctor = null;
+  state.retrying = null;
+  state.stopRequested = false;
+  state.visited = new Set();
+  state.isScraping = true;
+
+  await updateStatus({
+    message: `Found ${state.queue.length} doctor profiles. Starting...`,
+    total: state.queue.length,
+    processed: 0,
+    pending: state.queue.length,
+  });
+
+  processQueue().catch(async (error) => {
+    console.error("Scraping failed", error);
+    recordError("global", error.message);
+    state.isScraping = false;
+    state.stopRequested = false;
+    await cleanupScraperTab();
+    await updateStatus({
+      message: `Scraping failed: ${error.message}`,
+      isScraping: false,
+    });
+    resetState();
+  });
+
+  return { status: "started", total: state.queue.length };
+}
+
+async function handleStopScraping() {
+  await configReady;
+
+  if (!state.isScraping) {
+    await cleanupScraperTab();
+    resetState();
+    await updateStatus({ message: "Idle.", isScraping: false, total: 0, processed: 0, pending: 0 });
+    return { status: "idle" };
+  }
+
+  state.stopRequested = true;
+  await updateStatus({
+    message: "Stop requested. Waiting for the current profile to finish...",
+  });
+  return { status: "stopping" };
+}
+
+async function handleGetStatus() {
+  await configReady;
+  const stored = await chrome.storage.local.get(STATUS_STORAGE_KEY);
+  const status = stored?.[STATUS_STORAGE_KEY];
+  if (status) {
+    return {
+      ...status,
+      delayMs: status.delayMs ?? state.delayMs,
+      maxRetries: status.maxRetries ?? state.maxRetries,
+    };
+  }
+  return {
+    isScraping: false,
+    total: 0,
+    processed: 0,
+    pending: 0,
+    errors: [],
+    message: "Idle.",
+    delayMs: state.delayMs,
+    maxRetries: state.maxRetries,
+    lastDoctor: null,
+    retrying: null,
+  };
+}
+
+async function handleUpdateConfig(config) {
+  await applyConfig(config ?? {}, { persist: true });
+  await updateStatus({});
+  return { delayMs: state.delayMs, maxRetries: state.maxRetries };
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || !message.action) {
+    return;
+  }
+
+  if (message.action === "startScraping") {
+    handleStartScraping(message.payload)
+      .then((result) => sendResponse(result))
+      .catch((error) => sendResponse({ status: "error", message: error.message }));
+    return true;
+  }
+
+  if (message.action === "stopScraping") {
+    handleStopScraping()
+      .then((result) => sendResponse(result))
+      .catch((error) => sendResponse({ status: "error", message: error.message }));
+    return true;
+  }
+
+  if (message.action === "getStatus") {
+    handleGetStatus()
+      .then((status) => sendResponse({ status: "ok", data: status }))
+      .catch((error) => sendResponse({ status: "error", message: error.message }));
+    return true;
+  }
+
+  if (message.action === "updateConfig") {
+    handleUpdateConfig(message.payload)
+      .then((config) => sendResponse({ status: "ok", data: config }))
+      .catch((error) => sendResponse({ status: "error", message: error.message }));
+    return true;
+  }
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  resetState();
+  chrome.storage.local.set({
+    [CONFIG_STORAGE_KEY]: {
+      delayMs: state.delayMs,
+      maxRetries: state.maxRetries,
+    },
+    [STATUS_STORAGE_KEY]: {
+      isScraping: false,
+      total: 0,
+      processed: 0,
+      pending: 0,
+      errors: [],
+      message: "Idle.",
+      delayMs: state.delayMs,
+      maxRetries: state.maxRetries,
+      lastDoctor: null,
+      retrying: null,
+    },
+  });
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId === state.scraperTabId) {
+    state.scraperTabId = null;
+  }
+  if (tabId === state.listTabId) {
+    state.listTabId = null;
+  }
+});
+
+configReady
+  .then(() => updateStatus({}))
+  .catch((error) => console.error("Failed to publish initial status", error));

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,719 @@
+const DIGIT_MAP = {
+  "۰": "0",
+  "۱": "1",
+  "۲": "2",
+  "۳": "3",
+  "۴": "4",
+  "۵": "5",
+  "۶": "6",
+  "۷": "7",
+  "۸": "8",
+  "۹": "9",
+  "٠": "0",
+  "١": "1",
+  "٢": "2",
+  "٣": "3",
+  "٤": "4",
+  "٥": "5",
+  "٦": "6",
+  "٧": "7",
+  "٨": "8",
+  "٩": "9",
+};
+
+const LOAD_MORE_SELECTORS = [
+  "button[data-role='load-more']",
+  "button.load-more",
+  "button.more-doctors",
+  ".load-more button",
+  "button[data-action='load-more']",
+  "button.show-more",
+  "a[data-role='load-more']",
+];
+
+const DOCTOR_LINK_SELECTORS = [
+  "a.doctor-ui",
+  "a[data-role='doctor-card']",
+  "a.doctor-card",
+  ".doctor-ui a[href]",
+  "a[href*='/doctor/']",
+  "a[href*='/dr/']",
+  "a[href*='/profile/doctor']",
+];
+
+const DOCTOR_LINK_ATTRIBUTE_SELECTORS = [
+  "[data-profile-url]",
+  "[data-doctor-url]",
+  "[data-url]",
+  "[data-link]",
+];
+
+const PHONE_CONTAINER_SELECTORS = [
+  ".office-description",
+  ".office-contact",
+  "[data-role='tells-container']",
+  ".doctor-phone",
+  ".doctor-phones",
+  ".phone-number",
+  ".contact-phone",
+  ".contact-item",
+];
+
+const ADDRESS_CONTAINER_SELECTORS = [
+  ".office-address",
+  ".doctor-address",
+  "[data-role='address']",
+  "[itemprop='streetAddress']",
+  ".address",
+  ".clinic-address",
+];
+
+function toAbsoluteUrl(url) {
+  try {
+    return new URL(url, window.location.href).href;
+  } catch (error) {
+    return url;
+  }
+}
+
+function convertLocaleDigits(value) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  return String(value).replace(/[٠-٩۰-۹]/g, (digit) => DIGIT_MAP[digit] ?? digit);
+}
+
+function normaliseWhitespace(value) {
+  return convertLocaleDigits(value)
+    .replace(/\u200c/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normaliseText(value) {
+  return normaliseWhitespace(value);
+}
+
+function normalisePhoneText(value) {
+  const cleaned = normaliseWhitespace(value);
+  if (!cleaned) {
+    return "";
+  }
+  return cleaned.replace(/^(?:تلفن|شماره|call|phone)[:：\s-]*/i, "");
+}
+
+function normalisePhoneKey(value) {
+  return convertLocaleDigits(value).replace(/[^0-9+]/g, "");
+}
+
+function createCollector(transform = normaliseText, keyFn) {
+  const seen = new Set();
+  const values = [];
+  return {
+    add(value) {
+      const transformed = transform ? transform(value) : value;
+      if (!transformed) {
+        return;
+      }
+      const key = keyFn ? keyFn(value, transformed) : transformed;
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      values.push(transformed);
+    },
+    values() {
+      return values.slice();
+    },
+  };
+}
+
+function isElementVisible(element) {
+  if (!element) {
+    return false;
+  }
+  if (element.offsetParent === null && element.getClientRects().length === 0) {
+    return false;
+  }
+  const style = window.getComputedStyle(element);
+  return style.visibility !== "hidden" && style.display !== "none";
+}
+
+function isLoadMoreButtonUsable(button) {
+  if (!button) {
+    return false;
+  }
+  if (button.disabled || button.getAttribute("aria-disabled") === "true") {
+    return false;
+  }
+  if (button.classList.contains("disabled") || button.classList.contains("d-none")) {
+    return false;
+  }
+  return isElementVisible(button);
+}
+
+function findLoadMoreButton() {
+  for (const selector of LOAD_MORE_SELECTORS) {
+    const candidates = Array.from(document.querySelectorAll(selector));
+    for (const candidate of candidates) {
+      if (isLoadMoreButtonUsable(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function waitForElement(selector, timeout = 5000) {
+  const existing = document.querySelector(selector);
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeout);
+
+    function handleMutations() {
+      const element = document.querySelector(selector);
+      if (element) {
+        cleanup();
+        resolve(element);
+      }
+    }
+
+    function cleanup() {
+      clearTimeout(timer);
+      observer.disconnect();
+    }
+
+    const observer = new MutationObserver(handleMutations);
+    observer.observe(document.documentElement || document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+function getDoctorCardCount() {
+  return document.querySelectorAll(
+    ["a.doctor-ui", "a[data-role='doctor-card']", "[data-profile-url]", "[data-doctor-url]"]
+      .join(",")
+  ).length;
+}
+
+function waitForDoctorCardCountIncrease(previousCount, timeout = 6000) {
+  return new Promise((resolve) => {
+    let resolved = false;
+
+    function finish(count) {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      cleanup();
+      resolve(count);
+    }
+
+    function checkCount() {
+      const current = getDoctorCardCount();
+      if (current > previousCount) {
+        finish(current);
+      }
+    }
+
+    const observer = new MutationObserver(checkCount);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    const timer = setTimeout(() => finish(getDoctorCardCount()), timeout);
+
+    function cleanup() {
+      clearTimeout(timer);
+      observer.disconnect();
+    }
+
+    checkCount();
+  });
+}
+
+async function loadAdditionalDoctorCards(maxIterations = 12) {
+  let iteration = 0;
+  let previousCount = getDoctorCardCount();
+
+  while (iteration < maxIterations) {
+    const button = findLoadMoreButton();
+    if (!button) {
+      break;
+    }
+
+    button.scrollIntoView({ block: "center" });
+    button.click();
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    const updatedCount = await waitForDoctorCardCountIncrease(previousCount, 7000);
+    if (!updatedCount || updatedCount <= previousCount) {
+      break;
+    }
+
+    previousCount = updatedCount;
+    iteration += 1;
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  }
+}
+
+function normaliseProfileLink(rawLink) {
+  if (!rawLink) {
+    return null;
+  }
+  if (/^javascript:/i.test(rawLink)) {
+    return null;
+  }
+  try {
+    const url = new URL(toAbsoluteUrl(rawLink));
+    if (!/(^|\.)nobat\.ir$/i.test(url.hostname)) {
+      return null;
+    }
+    url.protocol = "https:";
+    url.hash = "";
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function collectDoctorLinksFromDom() {
+  const links = new Set();
+
+  DOCTOR_LINK_SELECTORS.forEach((selector) => {
+    const anchors = Array.from(document.querySelectorAll(selector));
+    anchors.forEach((anchor) => {
+      const href = anchor.getAttribute("href") || anchor.dataset?.href || anchor.dataset?.profileUrl;
+      const url = normaliseProfileLink(href);
+      if (url) {
+        links.add(url);
+      }
+    });
+  });
+
+  DOCTOR_LINK_ATTRIBUTE_SELECTORS.forEach((selector) => {
+    const elements = Array.from(document.querySelectorAll(selector));
+    elements.forEach((element) => {
+      const attributeNames = ["data-profile-url", "data-doctor-url", "data-url", "data-link"];
+      attributeNames.forEach((attrName) => {
+        const value = element.getAttribute(attrName);
+        const url = normaliseProfileLink(value);
+        if (url) {
+          links.add(url);
+        }
+      });
+
+      if (element.dataset) {
+        Object.keys(element.dataset)
+          .filter((key) => /profile|doctor|url|link/i.test(key))
+          .forEach((key) => {
+            const url = normaliseProfileLink(element.dataset[key]);
+            if (url) {
+              links.add(url);
+            }
+          });
+      }
+    });
+  });
+
+  return Array.from(links);
+}
+
+async function gatherDoctorLinks() {
+  await waitForElement("a.doctor-ui, [data-profile-url]");
+  await loadAdditionalDoctorCards();
+  return collectDoctorLinksFromDom();
+}
+
+function extractText(selector, root = document) {
+  const element = root.querySelector(selector);
+  return element ? normaliseText(element.textContent) : "";
+}
+
+function extractStructuredEntries() {
+  const entries = [];
+  const scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+
+  scripts.forEach((script) => {
+    const text = script.textContent?.trim();
+    if (!text) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(text);
+      const items = Array.isArray(parsed) ? parsed : [parsed];
+      items.forEach((item) => {
+        if (item && typeof item === "object") {
+          entries.push(item);
+        }
+      });
+    } catch (error) {
+      // Ignore malformed JSON-LD blocks.
+    }
+  });
+
+  return entries;
+}
+
+function extractDoctorName(structuredEntries) {
+  const heading = document.querySelector("h1.doctor-ui-name");
+  if (heading) {
+    const ellipsis = heading.querySelector(".text-ellipsis");
+    const text = ellipsis ? ellipsis.textContent : heading.textContent;
+    const normalised = normaliseText(text);
+    if (normalised) {
+      return normalised;
+    }
+  }
+
+  const fallback = document.querySelector("[itemprop='name']");
+  if (fallback) {
+    const normalised = normaliseText(fallback.textContent);
+    if (normalised) {
+      return normalised;
+    }
+  }
+
+  for (const entry of structuredEntries) {
+    const name = normaliseText(entry?.name);
+    if (name) {
+      return name;
+    }
+  }
+
+  return "";
+}
+
+function extractDoctorSpecialty(structuredEntries) {
+  const selectors = [
+    "h2.doctor-ui-specialty",
+    ".doctor-ui-specialty",
+    ".doctor-specialty",
+    "[data-role='doctor-specialty']",
+    "[itemprop='medicalSpecialty']",
+  ];
+
+  for (const selector of selectors) {
+    const text = extractText(selector);
+    if (text) {
+      return text;
+    }
+  }
+
+  for (const entry of structuredEntries) {
+    const specialty = entry?.medicalSpecialty || entry?.specialty || entry?.department;
+    if (Array.isArray(specialty)) {
+      const normalised = specialty.map((value) => normaliseText(value)).filter(Boolean);
+      if (normalised.length) {
+        return normalised.join("، ");
+      }
+    } else if (specialty) {
+      const normalised = normaliseText(specialty);
+      if (normalised) {
+        return normalised;
+      }
+    }
+  }
+
+  return "";
+}
+
+function extractDoctorCode(structuredEntries) {
+  const candidates = [];
+  const primary = document.querySelector(".doctor-code span:last-child");
+  if (primary) {
+    candidates.push(primary.textContent);
+  }
+  const fallback = document.querySelector(".doctor-code");
+  if (fallback) {
+    candidates.push(fallback.textContent);
+  }
+  const meta = document.querySelector("[data-role='doctor-code']");
+  if (meta) {
+    candidates.push(meta.textContent);
+  }
+
+  structuredEntries.forEach((entry) => {
+    if (entry?.identifier) {
+      candidates.push(entry.identifier);
+    }
+  });
+
+  for (const candidate of candidates) {
+    const text = normaliseText(candidate);
+    if (!text) {
+      continue;
+    }
+    const digits = text.replace(/[^0-9]/g, "");
+    if (digits) {
+      return digits;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const text = normaliseText(candidate);
+    if (text) {
+      return text;
+    }
+  }
+
+  return "";
+}
+
+function normaliseAddressText(text) {
+  return normaliseText(text);
+}
+
+function collectOfficeAddresses(structuredEntries) {
+  const addressCollector = createCollector(normaliseAddressText);
+  const cityCollector = createCollector(normaliseText);
+
+  const officeContainers = Array.from(
+    document.querySelectorAll(".office, .doctor-office, .office-item, .doctor-ui-office")
+  );
+
+  officeContainers.forEach((office) => {
+    const cityData = office.getAttribute("data-city") || office.dataset?.city;
+    cityCollector.add(cityData);
+
+    const addressNodes = Array.from(office.querySelectorAll(ADDRESS_CONTAINER_SELECTORS.join(",")));
+    if (addressNodes.length) {
+      addressNodes.forEach((node) => {
+        const strongs = Array.from(node.querySelectorAll("strong"));
+        if (strongs.length > 1) {
+          cityCollector.add(strongs[0]?.textContent);
+          addressCollector.add(strongs[strongs.length - 1]?.textContent);
+        } else if (strongs.length === 1) {
+          addressCollector.add(strongs[0].textContent);
+        } else {
+          addressCollector.add(node.textContent);
+        }
+      });
+    } else {
+      addressCollector.add(office.textContent);
+    }
+  });
+
+  if (!officeContainers.length) {
+    const fallbackNodes = Array.from(document.querySelectorAll(ADDRESS_CONTAINER_SELECTORS.join(",")));
+    fallbackNodes.forEach((node) => {
+      const strongs = Array.from(node.querySelectorAll("strong"));
+      if (strongs.length > 1) {
+        cityCollector.add(strongs[0]?.textContent);
+        addressCollector.add(strongs[strongs.length - 1]?.textContent);
+      } else {
+        addressCollector.add(node.textContent);
+      }
+    });
+  }
+
+  const locality = document.querySelector("[itemprop='addressLocality']");
+  if (locality) {
+    cityCollector.add(locality.textContent);
+  }
+
+  structuredEntries.forEach((entry) => {
+    if (entry?.addressLocality) {
+      cityCollector.add(entry.addressLocality);
+    }
+    const addresses = entry?.address;
+    const addressList = Array.isArray(addresses) ? addresses : addresses ? [addresses] : [];
+    addressList.forEach((address) => {
+      if (!address) {
+        return;
+      }
+      if (typeof address === "string") {
+        addressCollector.add(address);
+        return;
+      }
+      if (address.streetAddress) {
+        addressCollector.add(address.streetAddress);
+      }
+      if (address.addressLocality) {
+        cityCollector.add(address.addressLocality);
+      }
+    });
+  });
+
+  const addresses = addressCollector.values();
+  const city = cityCollector.values().find(Boolean) || "";
+
+  return { city, addresses };
+}
+
+function addPhoneCandidate(collector, value) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => addPhoneCandidate(collector, item));
+    return;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    if ((trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        addPhoneCandidate(collector, parsed);
+        return;
+      } catch (error) {
+        // Ignore malformed JSON-like strings and treat them as plain text.
+      }
+    }
+    collector.add(trimmed);
+    return;
+  }
+  if (typeof value === "object") {
+    Object.values(value).forEach((item) => addPhoneCandidate(collector, item));
+    return;
+  }
+  collector.add(String(value));
+}
+
+function collectPhonesFromStructuredData(structuredEntries, addPhone) {
+  structuredEntries.forEach((entry) => {
+    const telephone = entry?.telephone;
+    const telephones = Array.isArray(telephone) ? telephone : telephone ? [telephone] : [];
+    telephones.forEach(addPhone);
+
+    const contactPoints = Array.isArray(entry?.contactPoint) ? entry.contactPoint : [];
+    contactPoints.forEach((point) => {
+      if (!point) {
+        return;
+      }
+      addPhone(point.telephone);
+    });
+
+    const addresses = Array.isArray(entry?.address) ? entry.address : entry?.address ? [entry.address] : [];
+    addresses.forEach((address) => {
+      if (!address || typeof address !== "object") {
+        return;
+      }
+      addPhone(address.telephone);
+    });
+  });
+}
+
+function collectPhoneNumbers(structuredEntries) {
+  const collector = createCollector(normalisePhoneText, (_, value) => normalisePhoneKey(value));
+
+  const phoneContainers = Array.from(document.querySelectorAll(PHONE_CONTAINER_SELECTORS.join(",")));
+  phoneContainers.forEach((container) => {
+    const rawText = normaliseWhitespace(container.textContent || "");
+    if (!rawText) {
+      return;
+    }
+    rawText
+      .split(/\n|،|,|؛|;|\||\//)
+      .map((item) => item.trim())
+      .forEach((item) => addPhoneCandidate(collector, item));
+  });
+
+  const telLinks = Array.from(document.querySelectorAll("a[href^='tel:']"));
+  telLinks.forEach((link) => {
+    const href = link.getAttribute("href") || "";
+    addPhoneCandidate(collector, href.replace(/^tel:/i, ""));
+    addPhoneCandidate(collector, link.textContent || "");
+  });
+
+  const dataSelectors = ["[data-phone]", "[data-tel]", "[data-tell]", "[data-mobile]", "[data-number]", "[data-phones]"];
+  dataSelectors.forEach((selector) => {
+    const elements = Array.from(document.querySelectorAll(selector));
+    elements.forEach((element) => {
+      const attrName = selector.replace(/[\[\]]/g, "");
+      const attrValue = element.getAttribute(attrName);
+      addPhoneCandidate(collector, attrValue);
+      if (element.dataset) {
+        Object.keys(element.dataset)
+          .filter((key) => /phone|tel|mobile|number/i.test(key))
+          .forEach((key) => addPhoneCandidate(collector, element.dataset[key]));
+      }
+    });
+  });
+
+  collectPhonesFromStructuredData(structuredEntries, (value) => addPhoneCandidate(collector, value));
+
+  return collector.values();
+}
+
+async function revealPhoneNumbers() {
+  const buttons = Array.from(
+    document.querySelectorAll("button[data-role='show-tells'], button.show-tells, [data-role='show-tells'] button")
+  );
+
+  if (!buttons.length) {
+    return;
+  }
+
+  for (const button of buttons) {
+    if (button.disabled || button.getAttribute("aria-disabled") === "true") {
+      continue;
+    }
+    button.scrollIntoView({ block: "center" });
+    button.click();
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 800));
+}
+
+async function scrapeDoctorDetails() {
+  await waitForElement("h1.doctor-ui-name, .doctor-ui-name, [itemprop='name']", 8000);
+  const structuredEntries = extractStructuredEntries();
+
+  await revealPhoneNumbers();
+
+  const { city, addresses } = collectOfficeAddresses(structuredEntries);
+
+  return {
+    name: extractDoctorName(structuredEntries),
+    specialty: extractDoctorSpecialty(structuredEntries),
+    code: extractDoctorCode(structuredEntries),
+    city,
+    addresses,
+    phones: collectPhoneNumbers(structuredEntries),
+    url: window.location.href,
+  };
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || !message.type) {
+    return;
+  }
+
+  if (message.type === "GET_DOCTOR_LINKS") {
+    (async () => {
+      try {
+        const links = await gatherDoctorLinks();
+        sendResponse({ links });
+      } catch (error) {
+        console.error("Failed to gather doctor links", error);
+        sendResponse({ error: error.message });
+      }
+    })();
+    return true;
+  }
+
+  if (message.type === "SCRAPE_DOCTOR_DETAILS") {
+    (async () => {
+      try {
+        const data = await scrapeDoctorDetails();
+        sendResponse({ data });
+      } catch (error) {
+        console.error("Failed to scrape doctor details", error);
+        sendResponse({ error: error.message });
+      }
+    })();
+    return true;
+  }
+});

--- a/extension/csv-export.js
+++ b/extension/csv-export.js
@@ -1,0 +1,62 @@
+const CSV_HEADERS = ["Name", "Specialty", "Code", "City", "Address", "Phones"];
+const UTF8_BOM = "\ufeff";
+
+function normaliseValue(value) {
+  if (Array.isArray(value)) {
+    const unique = Array.from(new Set(value.map((item) => String(item || "").trim()).filter(Boolean)));
+    return unique.join("; ");
+  }
+
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return String(value).trim();
+}
+
+function escapeCsvValue(value) {
+  const str = normaliseValue(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function convertToCsv(rows) {
+  const headerLine = CSV_HEADERS.join(",");
+  const dataLines = rows.map((row) => {
+    return CSV_HEADERS
+      .map((header) => {
+        const key = header.toLowerCase();
+        return escapeCsvValue(row[key]);
+      })
+      .join(",");
+  });
+
+  return [headerLine, ...dataLines].join("\n");
+}
+
+function download(options) {
+  return new Promise((resolve, reject) => {
+    chrome.downloads.download(options, (downloadId) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(downloadId);
+    });
+  });
+}
+
+export async function downloadCsv(filename, rows) {
+  const csvContent = typeof rows === "string" ? rows : convertToCsv(rows);
+  const blob = new Blob([UTF8_BOM, csvContent], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    await download({ url, filename, saveAs: false });
+  } finally {
+    // Give the download API time to consume the object URL before revoking it.
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Nobat.ir Doctor Scraper",
+  "description": "Scrape doctor information from Nobat.ir and export it to CSV.",
+  "version": "1.0.0",
+  "manifest_version": 3,
+  "permissions": [
+    "tabs",
+    "scripting",
+    "downloads",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://nobat.ir/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Nobat.ir Doctor Scraper"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://nobat.ir/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nobat.ir Doctor Scraper</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        margin: 16px;
+        min-width: 260px;
+        color: #222;
+      }
+
+      h1 {
+        font-size: 16px;
+        margin: 0 0 12px;
+      }
+
+      .controls {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+
+      button {
+        padding: 6px 12px;
+        border: none;
+        border-radius: 4px;
+        background-color: #1976d2;
+        color: #fff;
+        cursor: pointer;
+        font-size: 13px;
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      button.stop {
+        background-color: #c62828;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 10px;
+      }
+
+      .field label {
+        font-size: 12px;
+        margin-bottom: 4px;
+        color: #555;
+      }
+
+      .field input {
+        border: 1px solid #c7c7c7;
+        border-radius: 4px;
+        padding: 6px 8px;
+        font-size: 13px;
+      }
+
+      #status {
+        margin-top: 6px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      #progress,
+      #retry,
+      #last-doctor {
+        margin-top: 4px;
+        font-size: 12px;
+        color: #555;
+      }
+
+      #last-doctor a {
+        color: #1976d2;
+        text-decoration: none;
+      }
+
+      #last-doctor a:hover {
+        text-decoration: underline;
+      }
+
+      #retry {
+        color: #a15b00;
+      }
+
+      #errors {
+        margin-top: 8px;
+        color: #c62828;
+        font-size: 12px;
+        white-space: pre-line;
+        display: none;
+      }
+
+      .muted {
+        color: #777;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Nobat.ir Scraper</h1>
+    <div class="controls">
+      <button id="start">Start</button>
+      <button id="stop" class="stop">Stop</button>
+    </div>
+    <div class="field">
+      <label for="delay">Delay between profiles (seconds)</label>
+      <input id="delay" type="number" min="0" step="0.5" value="2.5" />
+    </div>
+    <div class="field">
+      <label for="retries">Max retries per profile</label>
+      <input id="retries" type="number" min="0" max="5" step="1" value="2" />
+    </div>
+    <div id="status">Status: Idle</div>
+    <div id="progress" class="muted"></div>
+    <div id="last-doctor" class="muted"></div>
+    <div id="retry"></div>
+    <div id="errors"></div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,276 @@
+const DEFAULT_DELAY_SECONDS = 2.5;
+const DEFAULT_MAX_RETRIES = 2;
+const MAX_RETRIES_LIMIT = 5;
+
+const startButton = document.getElementById("start");
+const stopButton = document.getElementById("stop");
+const statusElement = document.getElementById("status");
+const progressElement = document.getElementById("progress");
+const errorsElement = document.getElementById("errors");
+const delayInput = document.getElementById("delay");
+const retriesInput = document.getElementById("retries");
+const lastDoctorElement = document.getElementById("last-doctor");
+const retryElement = document.getElementById("retry");
+
+stopButton.disabled = true;
+errorsElement.style.display = "none";
+lastDoctorElement.style.display = "none";
+retryElement.style.display = "none";
+progressElement.textContent = "";
+
+function updateButtons(isScraping) {
+  startButton.disabled = !!isScraping;
+  stopButton.disabled = !isScraping;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function parseDelayInput() {
+  const value = parseFloat(delayInput.value);
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_DELAY_SECONDS;
+  }
+  return Math.round(value * 100) / 100;
+}
+
+function parseRetriesInput() {
+  const value = parseInt(retriesInput.value, 10);
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_MAX_RETRIES;
+  }
+  return clamp(Math.round(value), 0, MAX_RETRIES_LIMIT);
+}
+
+function formatErrors(errors = []) {
+  if (!Array.isArray(errors) || !errors.length) {
+    return "";
+  }
+  return errors
+    .map((error) => {
+      if (!error) {
+        return "";
+      }
+      if (typeof error === "string") {
+        return `• ${error}`;
+      }
+      const parts = [];
+      if (error.url && error.url !== "global") {
+        parts.push(error.url);
+      }
+      if (error.message) {
+        parts.push(error.message);
+      }
+      const text = parts.join(" - ") || "Unknown error";
+      return `• ${text}`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatDelaySeconds(delayMs) {
+  const seconds = Math.max(0, Number(delayMs ?? DEFAULT_DELAY_SECONDS * 1000) / 1000);
+  return (Math.round(seconds * 100) / 100).toString();
+}
+
+function setDelayInputValue(delayMs) {
+  if (document.activeElement === delayInput) {
+    return;
+  }
+  delayInput.value = formatDelaySeconds(delayMs);
+}
+
+function setRetriesInputValue(retries) {
+  if (document.activeElement === retriesInput) {
+    return;
+  }
+  const value = Number.isFinite(retries) ? clamp(Math.round(retries), 0, MAX_RETRIES_LIMIT) : DEFAULT_MAX_RETRIES;
+  retriesInput.value = value.toString();
+}
+
+function renderLastDoctor(lastDoctor) {
+  if (!lastDoctor || (!lastDoctor.name && !lastDoctor.url)) {
+    lastDoctorElement.textContent = "";
+    lastDoctorElement.style.display = "none";
+    return;
+  }
+
+  lastDoctorElement.textContent = "";
+  const label = document.createElement("span");
+  label.textContent = "Last profile: ";
+  lastDoctorElement.appendChild(label);
+
+  if (lastDoctor.url) {
+    const link = document.createElement("a");
+    link.href = lastDoctor.url;
+    link.textContent = lastDoctor.name || lastDoctor.url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    lastDoctorElement.appendChild(link);
+  } else if (lastDoctor.name) {
+    lastDoctorElement.append(lastDoctor.name);
+  }
+
+  lastDoctorElement.style.display = "block";
+}
+
+function applyStatus(status) {
+  if (!status) {
+    statusElement.textContent = "Status: Unknown";
+    progressElement.textContent = "";
+    retryElement.textContent = "";
+    retryElement.style.display = "none";
+    lastDoctorElement.textContent = "";
+    lastDoctorElement.style.display = "none";
+    errorsElement.textContent = "";
+    errorsElement.style.display = "none";
+    updateButtons(false);
+    return;
+  }
+
+  const isScraping = Boolean(status.isScraping);
+  const message = status.message || (isScraping ? "Scraping in progress..." : "Idle.");
+  statusElement.textContent = `Status: ${message}`;
+
+  const total = Number(status.total) || 0;
+  const processed = Number(status.processed) || 0;
+  const pending = status.pending !== undefined ? Number(status.pending) : Math.max(total - processed, 0);
+
+  if (total > 0) {
+    const percentage = Math.min(100, Math.max(0, (processed / total) * 100));
+    const percentText = `${percentage.toFixed(1)}%`;
+    const progressParts = [`Progress: ${processed} / ${total} (${percentText})`];
+    if (pending > 0) {
+      progressParts.push(`Pending: ${pending}`);
+    }
+    progressElement.textContent = progressParts.join(" · ");
+  } else {
+    progressElement.textContent = "";
+  }
+
+  const errorText = formatErrors(status.errors);
+  if (errorText) {
+    const errorCount = Array.isArray(status.errors) ? status.errors.length : 0;
+    errorsElement.textContent = `Errors (${errorCount}):\n${errorText}`;
+    errorsElement.style.display = "block";
+  } else {
+    errorsElement.textContent = "";
+    errorsElement.style.display = "none";
+  }
+
+  if (status.retrying && status.retrying.attempt && status.retrying.total) {
+    retryElement.textContent = `Retrying current profile (${status.retrying.attempt} / ${status.retrying.total})...`;
+    retryElement.style.display = "block";
+  } else {
+    retryElement.textContent = "";
+    retryElement.style.display = "none";
+  }
+
+  renderLastDoctor(status.lastDoctor);
+  setDelayInputValue(status.delayMs);
+  setRetriesInputValue(status.maxRetries);
+
+  updateButtons(isScraping);
+}
+
+function sendAction(action, payload) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ action, payload }, (response) => {
+      if (chrome.runtime.lastError) {
+        resolve({ status: "error", message: chrome.runtime.lastError.message });
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+async function persistConfig() {
+  const delaySeconds = parseDelayInput();
+  const maxRetries = parseRetriesInput();
+  delayInput.value = delaySeconds.toString();
+  retriesInput.value = maxRetries.toString();
+
+  await sendAction("updateConfig", {
+    delayMs: Math.round(delaySeconds * 1000),
+    maxRetries,
+  });
+}
+
+async function refreshStatus() {
+  const response = await sendAction("getStatus");
+  if (response?.status === "ok") {
+    applyStatus(response.data);
+  } else if (response?.status === "error") {
+    statusElement.textContent = `Status: ${response.message}`;
+    updateButtons(false);
+  }
+}
+
+startButton.addEventListener("click", async () => {
+  updateButtons(true);
+  const delaySeconds = parseDelayInput();
+  const maxRetries = parseRetriesInput();
+
+  delayInput.value = delaySeconds.toString();
+  retriesInput.value = maxRetries.toString();
+
+  const response = await sendAction("startScraping", {
+    delayMs: Math.round(delaySeconds * 1000),
+    maxRetries,
+  });
+
+  if (!response) {
+    statusElement.textContent = "Status: Failed to communicate with background script.";
+    updateButtons(false);
+    return;
+  }
+
+  if (response.status === "started") {
+    statusElement.textContent = "Status: Scraping started.";
+  } else if (response.status === "no-links") {
+    statusElement.textContent = "Status: No doctor links found on this page.";
+    updateButtons(false);
+  } else if (response.status === "already-running") {
+    statusElement.textContent = "Status: Scraping is already running.";
+  } else if (response.status === "error") {
+    statusElement.textContent = `Status: ${response.message}`;
+    updateButtons(false);
+  }
+
+  await refreshStatus();
+});
+
+stopButton.addEventListener("click", async () => {
+  startButton.disabled = true;
+  stopButton.disabled = true;
+
+  const response = await sendAction("stopScraping");
+
+  if (response?.status === "stopping") {
+    statusElement.textContent = "Status: Stop requested. Waiting for the current profile...";
+  } else if (response?.status === "idle") {
+    statusElement.textContent = "Status: Idle.";
+  } else if (response?.status === "error") {
+    statusElement.textContent = `Status: ${response.message}`;
+  }
+
+  await refreshStatus();
+});
+
+delayInput.addEventListener("change", () => {
+  persistConfig().catch(() => {});
+});
+
+retriesInput.addEventListener("change", () => {
+  persistConfig().catch(() => {});
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type === "SCRAPE_STATUS") {
+    applyStatus(message.payload);
+  }
+});
+
+refreshStatus();


### PR DESCRIPTION
## Summary
- rebuild the background service worker to persist scraping configuration, reuse a single worker tab, handle retries/partial stops, and emit richer status updates
- expand the content script to auto-expand doctor lists, normalise data (including Persian digits), and aggregate phones/addresses from multiple sources before exporting with a UTF-8 BOM
- refresh the popup UI with configurable delay/retry controls, detailed progress feedback, and document the new workflow in the README

## Testing
- Not run (Chrome extension)


------
https://chatgpt.com/codex/tasks/task_e_68cfce8fcf30832683670eae0ba031dd