### PR TITLE
Handle unsupported autoDiscardable in tab creation

### DIFF
--- a/extension/csv-export.js
+++ b/extension/csv-export.js
@@ -48,15 +48,61 @@ function download(options) {
   });
 }
 
-export async function downloadCsv(filename, rows) {
-  const csvContent = typeof rows === "string" ? rows : convertToCsv(rows);
-  const blob = new Blob([UTF8_BOM, csvContent], { type: "text/csv;charset=utf-8" });
-  const url = URL.createObjectURL(blob);
+function ensureUtf8Bom(csvContent) {
+  if (typeof csvContent !== "string") {
+    return `${UTF8_BOM}${String(csvContent ?? "")}`;
+  }
+
+  return csvContent.startsWith(UTF8_BOM) ? csvContent : `${UTF8_BOM}${csvContent}`;
+}
+
+function encodeCsvAsDataUrl(csvText) {
+  return `data:text/csv;charset=utf-8,${encodeURIComponent(csvText)}`;
+}
+
+async function downloadViaBlobUrl(filename, csvText) {
+  let url;
+
+  try {
+    const blob = new Blob([csvText], { type: "text/csv;charset=utf-8" });
+    url = URL.createObjectURL(blob);
+    await download({ url, filename, saveAs: false });
+    // Give the download API time to consume the object URL before revoking it.
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  } catch (error) {
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+    throw error;
+  }
+}
+
+async function downloadViaDataUrl(filename, csvText, initialError) {
+  const url = encodeCsvAsDataUrl(csvText);
 
   try {
     await download({ url, filename, saveAs: false });
-  } finally {
-    // Give the download API time to consume the object URL before revoking it.
-    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  } catch (error) {
+    if (initialError) {
+      const combinedError = new Error(
+        `Failed to download CSV (blob URL error: ${initialError.message}; data URL fallback: ${error.message})`
+      );
+      combinedError.cause = { blob: initialError, dataUrl: error };
+      throw combinedError;
+    }
+    throw error;
+  }
+}
+
+export async function downloadCsv(filename, rows) {
+  const csvContent = typeof rows === "string" ? rows : convertToCsv(rows);
+  const csvText = ensureUtf8Bom(csvContent);
+
+  try {
+    await downloadViaBlobUrl(filename, csvText);
+    return;
+  } catch (error) {
+    console.warn("Blob URL download failed, falling back to data URL.", error);
+    await downloadViaDataUrl(filename, csvText, error);
   }
 }


### PR DESCRIPTION
## Summary
- avoid passing the unsupported `autoDiscardable` flag to `chrome.tabs.create`
- add a helper that toggles the flag via `chrome.tabs.update`, gracefully handling browsers that reject it
- reuse the helper when navigating the scraper tab so the tab stays discardable without breaking older Chrome versions
- add a data-URL fallback when blob-based CSV downloads fail so the export still works on browsers that reject object URLs

## Testing
- not run (extension change only)

------
https://chatgpt.com/codex/tasks/task_e_68cfde2ee19c83269d7999ea96e323ee