### PR TITLE
Handle pagination and preserve council code letters

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -39,6 +39,7 @@ const state = {
   listTabId: null,
   listWindowId: null,
   listTabIndex: null,
+  listInitialUrl: null,
   scraperTabId: null,
   delayMs: DEFAULT_CONFIG.delayMs,
   maxRetries: DEFAULT_CONFIG.maxRetries,
@@ -159,13 +160,40 @@ function normaliseOfficeList(offices) {
   return normalised;
 }
 
+function extractCodeToken(text) {
+  if (!text) {
+    return "";
+  }
+
+  const primaryMatch = text.match(/(?:\p{L}\s*)?\d+(?:\s*\p{L})?/u);
+  if (primaryMatch && primaryMatch[0]) {
+    return primaryMatch[0].replace(/\s+/g, "");
+  }
+
+  const tokens = text.split(/[^0-9\p{L}]+/u).filter(Boolean);
+  let numericFallback = "";
+
+  for (const token of tokens) {
+    if (/\d/.test(token)) {
+      if (/\p{L}/u.test(token)) {
+        return token;
+      }
+      if (!numericFallback) {
+        numericFallback = token;
+      }
+    }
+  }
+
+  return numericFallback;
+}
+
 function cleanDoctorCode(rawValue) {
   const text = normaliseText(rawValue);
   if (!text) {
     return "";
   }
-  const digits = text.replace(/[^0-9]/g, "");
-  return digits || text;
+  const parsed = extractCodeToken(text);
+  return parsed || text;
 }
 
 function normaliseDoctorData(data = {}, url) {
@@ -598,34 +626,125 @@ async function applyConfig(partialConfig = {}, { persist = false } = {}) {
   return { delayMs: state.delayMs, maxRetries: state.maxRetries };
 }
 
-async function getDoctorLinksFromTab(tabId) {
-  let response;
+async function requestDoctorLinksFromTab(tabId) {
   try {
-    response = await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
+    return await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
   } catch (error) {
     if (/Receiving end does not exist/i.test(error.message)) {
       await injectContentScript(tabId);
-      response = await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
-    } else {
-      throw error;
+      return await sendMessageToTab(tabId, { type: "GET_DOCTOR_LINKS" });
     }
+    throw error;
   }
+}
 
-  if (response?.error) {
-    throw new Error(response.error);
+function normaliseListPageUrl(rawUrl, baseUrl) {
+  if (!rawUrl) {
+    return null;
   }
+  try {
+    const url = new URL(rawUrl, baseUrl || state.listInitialUrl || "https://nobat.ir/");
+    if (!/(^|\.)nobat\.ir$/i.test(url.hostname)) {
+      return null;
+    }
+    url.protocol = "https:";
+    url.hash = "";
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
 
-  const rawLinks = Array.isArray(response?.links) ? response.links : [];
+async function restoreListTab(tabId, targetUrl) {
+  if (!targetUrl) {
+    return;
+  }
+  try {
+    await updateTab(tabId, { url: targetUrl });
+    await waitForTabLoad(tabId);
+  } catch (error) {
+    console.warn("Failed to restore list tab", error);
+  }
+}
+
+async function getDoctorLinksFromTab(tabId) {
   const unique = [];
   const seen = new Set();
+  const visitedPages = new Set();
+  const maxPages = 50;
+  let iterations = 0;
 
-  rawLinks.forEach((link) => {
-    const normalised = normaliseDoctorProfileUrl(link);
-    if (normalised && !seen.has(normalised)) {
-      seen.add(normalised);
-      unique.push(normalised);
+  let initialUrl = state.listInitialUrl || null;
+
+  try {
+    const tab = await getTab(tabId);
+    if (tab?.url) {
+      initialUrl = tab.url;
     }
-  });
+  } catch (error) {
+    console.warn("Failed to read initial list tab URL", error);
+  }
+
+  const normalisedInitial = normaliseListPageUrl(initialUrl, initialUrl);
+  if (normalisedInitial) {
+    visitedPages.add(normalisedInitial);
+  }
+
+  let currentBaseUrl = initialUrl;
+
+  while (iterations < maxPages) {
+    const response = await requestDoctorLinksFromTab(tabId);
+    if (response?.error) {
+      throw new Error(response.error);
+    }
+
+    const rawLinks = Array.isArray(response?.links) ? response.links : [];
+    rawLinks.forEach((link) => {
+      const normalised = normaliseDoctorProfileUrl(link);
+      if (normalised && !seen.has(normalised)) {
+        seen.add(normalised);
+        unique.push(normalised);
+      }
+    });
+
+    const currentTab = await getTab(tabId).catch(() => null);
+    if (currentTab?.url) {
+      currentBaseUrl = currentTab.url;
+      const normalisedCurrent = normaliseListPageUrl(currentBaseUrl, initialUrl);
+      if (normalisedCurrent) {
+        visitedPages.add(normalisedCurrent);
+      }
+    }
+
+    const nextPageRaw = response?.nextPageUrl;
+    const nextPageUrl = normaliseListPageUrl(nextPageRaw, currentBaseUrl || initialUrl);
+
+    if (!nextPageUrl || visitedPages.has(nextPageUrl)) {
+      break;
+    }
+
+    visitedPages.add(nextPageUrl);
+    iterations += 1;
+
+    await updateTab(tabId, { url: nextPageUrl });
+    await waitForTabLoad(tabId);
+  }
+
+  if (normalisedInitial) {
+    let currentNormalised = null;
+    try {
+      const currentTab = await getTab(tabId);
+      if (currentTab?.url) {
+        currentNormalised = normaliseListPageUrl(currentTab.url, initialUrl);
+      }
+    } catch (error) {
+      console.warn("Failed to read list tab URL during restore", error);
+    }
+
+    if (currentNormalised !== normalisedInitial) {
+      await restoreListTab(tabId, normalisedInitial);
+    }
+  }
 
   return unique;
 }
@@ -818,6 +937,7 @@ function resetState() {
   state.listTabId = null;
   state.listWindowId = null;
   state.listTabIndex = null;
+  state.listInitialUrl = null;
   state.scraperTabId = null;
   state.errors = [];
   state.lastDoctor = null;
@@ -930,6 +1050,8 @@ async function handleStartScraping(options = {}) {
   state.listTabId = activeTab.id;
   state.listWindowId = activeTab.windowId ?? null;
   state.listTabIndex = typeof activeTab.index === "number" ? activeTab.index + 1 : null;
+  const initialListUrl = normaliseListPageUrl(activeTab.url || null, activeTab.url || null);
+  state.listInitialUrl = initialListUrl || activeTab.url || null;
 
   await cleanupScraperTab();
 

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -48,6 +48,20 @@ const DOCTOR_LINK_ATTRIBUTE_SELECTORS = [
   "[data-link]",
 ];
 
+const NEXT_PAGE_SELECTORS = [
+  "a[rel='next']",
+  "a.pagination-next",
+  ".pagination a.next",
+  ".pagination li.next a",
+  ".pagination li.active + li a",
+  "a[aria-label='Next']",
+  "a[aria-label='next']",
+  "a[aria-label='بعد']",
+  "a[aria-label='بعدی']",
+  "a[aria-label*='بعد']",
+  "a[aria-label*='next']",
+];
+
 const PHONE_CONTAINER_SELECTORS = [
   ".office-description",
   ".office-contact",
@@ -325,10 +339,149 @@ function collectDoctorLinksFromDom() {
   return Array.from(links);
 }
 
+function isPaginationElementDisabled(element) {
+  if (!element) {
+    return true;
+  }
+  if (element.getAttribute && element.getAttribute("aria-disabled") === "true") {
+    return true;
+  }
+  if (
+    element.classList &&
+    (element.classList.contains("disabled") || element.classList.contains("d-none"))
+  ) {
+    return true;
+  }
+  const parent = element.closest ? element.closest("li") : null;
+  if (parent) {
+    if (parent.getAttribute("aria-disabled") === "true") {
+      return true;
+    }
+    if (parent.classList.contains("disabled") || parent.classList.contains("d-none")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalisePaginationUrl(href) {
+  if (!href) {
+    return null;
+  }
+  const trimmed = href.trim();
+  if (!trimmed || trimmed === "#") {
+    return null;
+  }
+  if (/^javascript:/i.test(trimmed)) {
+    return null;
+  }
+  return toAbsoluteUrl(trimmed);
+}
+
+function collectPaginationCandidates() {
+  const candidates = new Set();
+  NEXT_PAGE_SELECTORS.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((element) => {
+      candidates.add(element);
+    });
+  });
+
+  const paginationContainers = Array.from(
+    document.querySelectorAll(
+      ".pagination, nav[aria-label*='page'], nav[aria-label*='صفحه'], nav[role='navigation']"
+    )
+  );
+
+  paginationContainers.forEach((container) => {
+    const active = container.querySelector("li.active, .active");
+    if (active) {
+      let nextSibling = active.nextElementSibling;
+      while (nextSibling) {
+        const anchor = nextSibling.querySelector ? nextSibling.querySelector("a[href]") : null;
+        if (anchor) {
+          candidates.add(anchor);
+          break;
+        }
+        nextSibling = nextSibling.nextElementSibling;
+      }
+    }
+
+    container.querySelectorAll("a[href]").forEach((anchor) => {
+      candidates.add(anchor);
+    });
+  });
+
+  return Array.from(candidates);
+}
+
+function findNextPageUrl() {
+  const candidates = collectPaginationCandidates();
+  const scored = [];
+
+  candidates.forEach((candidate, index) => {
+    if (!candidate || isPaginationElementDisabled(candidate)) {
+      return;
+    }
+    const url = normalisePaginationUrl(candidate.getAttribute("href"));
+    if (!url) {
+      return;
+    }
+
+    const text = normaliseWhitespace(candidate.textContent || "").toLowerCase();
+    const aria = normaliseWhitespace(
+      (typeof candidate.getAttribute === "function" && candidate.getAttribute("aria-label")) || ""
+    ).toLowerCase();
+
+    let priority = 5 + index;
+    const hasNextRel = candidate.rel && /next/i.test(candidate.rel);
+    if (hasNextRel) {
+      priority = Math.min(priority, 0);
+    }
+    const looksLikeNext = /(\u0628\u0639\u062f|\u0628\u0639\u062f\u06cc|next|›|»)/i.test(text);
+    if (looksLikeNext) {
+      priority = Math.min(priority, 1);
+    }
+    const ariaIndicatesNext = /(\u0628\u0639\u062f|\u0628\u0639\u062f\u06cc|next)/i.test(aria);
+    if (ariaIndicatesNext) {
+      priority = Math.min(priority, 1);
+    }
+
+    const parent = candidate.closest ? candidate.closest("li") : null;
+    const hasNextClass = !!(
+      candidate.classList && Array.from(candidate.classList).some((cls) => /next|\u0628\u0639\u062f/i.test(cls))
+    );
+    const afterActive =
+      parent &&
+      parent.previousElementSibling &&
+      parent.previousElementSibling.classList &&
+      parent.previousElementSibling.classList.contains("active");
+
+    if (afterActive) {
+      priority = Math.min(priority, 2);
+    }
+
+    const qualifies = hasNextRel || looksLikeNext || ariaIndicatesNext || hasNextClass;
+    if (!qualifies && !afterActive) {
+      return;
+    }
+
+    scored.push({ url, priority });
+  });
+
+  if (!scored.length) {
+    return null;
+  }
+
+  scored.sort((a, b) => a.priority - b.priority);
+  return scored[0].url;
+}
+
 async function gatherDoctorLinks() {
   await waitForElement("a.doctor-ui, [data-profile-url]");
   await loadAdditionalDoctorCards();
-  return collectDoctorLinksFromDom();
+  const links = collectDoctorLinksFromDom();
+  const nextPageUrl = findNextPageUrl();
+  return { links, nextPageUrl };
 }
 
 function extractText(selector, root = document) {
@@ -424,6 +577,33 @@ function extractDoctorSpecialty(structuredEntries) {
   return "";
 }
 
+function extractCodeToken(text) {
+  if (!text) {
+    return "";
+  }
+
+  const primaryMatch = text.match(/(?:\p{L}\s*)?\d+(?:\s*\p{L})?/u);
+  if (primaryMatch && primaryMatch[0]) {
+    return primaryMatch[0].replace(/\s+/g, "");
+  }
+
+  const tokens = text.split(/[^0-9\p{L}]+/u).filter(Boolean);
+  let numericFallback = "";
+
+  for (const token of tokens) {
+    if (/\d/.test(token)) {
+      if (/\p{L}/u.test(token)) {
+        return token;
+      }
+      if (!numericFallback) {
+        numericFallback = token;
+      }
+    }
+  }
+
+  return numericFallback;
+}
+
 function extractDoctorCode(structuredEntries) {
   const candidates = [];
   const primary = document.querySelector(".doctor-code span:last-child");
@@ -450,9 +630,9 @@ function extractDoctorCode(structuredEntries) {
     if (!text) {
       continue;
     }
-    const digits = text.replace(/[^0-9]/g, "");
-    if (digits) {
-      return digits;
+    const parsed = extractCodeToken(text);
+    if (parsed) {
+      return parsed;
     }
   }
 
@@ -877,8 +1057,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "GET_DOCTOR_LINKS") {
     (async () => {
       try {
-        const links = await gatherDoctorLinks();
-        sendResponse({ links });
+        const { links, nextPageUrl } = await gatherDoctorLinks();
+        sendResponse({ links, nextPageUrl });
       } catch (error) {
         console.error("Failed to gather doctor links", error);
         sendResponse({ error: error.message });


### PR DESCRIPTION
## Summary
- add pagination discovery in the content script so listing pages reveal next-page URLs alongside gathered doctor profile links
- iterate over paginated result pages from the background script, restoring the original list tab once collection finishes
- update doctor code normalisation to retain Iranian medical council letter prefixes when scraping and when building CSV rows

## Testing
- not run (Chrome extension)


------
https://chatgpt.com/codex/tasks/task_e_68d92fd99a2c8326b4c155166d142a38