### PR TITLE
Expand office data columns in CSV export

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -713,15 +713,15 @@ function collectOfficeAddresses(structuredEntries) {
     }
     const addresses = Array.isArray(details.addresses)
       ? details.addresses
-      : details.addresses
-      ? [details.addresses]
+      : details.address
+      ? [details.address]
       : [];
     addresses.forEach((address) => officeAddressCollector.add(address));
 
     const phones = Array.isArray(details.phones)
       ? details.phones
-      : details.phones
-      ? [details.phones]
+      : details.phone
+      ? [details.phone]
       : [];
     phones.forEach((phone) => officePhoneCollector.add(phone));
 


### PR DESCRIPTION
## Summary
- add a reusable helper for normalising office field values during CSV generation
- expand dynamic office columns so each address and phone occupies its own column

## Testing
- node -c extension/csv-export.js

------
https://chatgpt.com/codex/tasks/task_e_68da491b4e40832691d35849b9df2180